### PR TITLE
`left-right` and `evmap`

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -512,7 +512,7 @@
                     "description": "",
                     "purposes": [
                         {
-                            "name": "Mutli reader, single writer",
+                            "name": "Concurrent",
                             "crates": [
                             {
                                 "name": "left-right",

--- a/data/crates.json
+++ b/data/crates.json
@@ -475,6 +475,9 @@
                             }, {
                                 "name": "flurry",
                                 "notes": "Particularly good for read-heavy workloads."
+                            }, {
+                                "name": "evmap",
+                                "notes": "Significantly more performant compared to flurry if there is only one writer, does support multiple writers with a mutex.
                             }]
                         },
                         {
@@ -499,6 +502,21 @@
                             {
                                 "name": "rayon",
                                 "notes": "Convert sequential computation into parallel computation with one call - `par_iter` instead of `iter`"
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "slug": "primitives",
+                    "name": "Primitives",
+                    "description": "",
+                    "purposes": [
+                        {
+                            "name": "Mutli reader, single writer",
+                            "crates": [
+                            {
+                                "name": "left-right",
+                                "notes": "A concurrency primitive for high concurrency reads over a single-writer data structure. Used by evmap."
                             }]
                         }
                     ]

--- a/data/crates.json
+++ b/data/crates.json
@@ -477,7 +477,7 @@
                                 "notes": "Particularly good for read-heavy workloads."
                             }, {
                                 "name": "evmap",
-                                "notes": "Significantly more performant compared to flurry if there is only one writer, does support multiple writers with a mutex.
+                                "notes": "Significantly more performant compared to flurry if there is only one writer, does support multiple writers with a mutex."
                             }]
                         },
                         {


### PR DESCRIPTION
Added [`left-right`](https://docs.rs/left-right/0.11.5/left_right/) under "Primitives -- Concurrent" and added [`evmap`](https://docs.rs/evmap/10.0.2/evmap/) under "Concurrency -- Concurrent HashMap".