### PR TITLE
fix: broken link for windows-rs

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -213,7 +213,7 @@
                         {
                             "name": "Windows (OS)",
                             "crates": [{
-                                "name": "windows-rs",
+                                "name": "windows",
                                 "notes": "The official Microsoft-provided crate for interacting with windows APIs"
                             }, {
                                 "name": "winapi",


### PR DESCRIPTION
Currently the windows-rs link is broken
It redirects to: https://docs.rs/windows-rs

But it should be https://docs.rs/windows/
This PR fixes that