### PR TITLE
fix: Hyper doesn't require tokio

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -382,7 +382,7 @@
                             "name": "Low-level HTTP Implementation",
                             "recommendations": [{
                                 "name": "hyper",
-                                "notes": "A low-level HTTP implementation (both client and server). Implements HTTP 1, 2, and 3. Requires the tokio async runtime."
+                                "notes": "A low-level HTTP implementation (both client and server). Implements HTTP 1, 2, and 3. Works best with the tokio async runtime, but can support other runtimes."
                             }]
                         },
                         {


### PR DESCRIPTION
Hyper supports tokio with the "runtime" and "tcp" features, but does not require it. Fuschia and curl both use their own runtime with hyper. https://github.com/hyperium/hyper/issues/2111