### PR TITLE
Add cargo-modules

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -31,6 +31,14 @@
                     }]
                 },
                 {
+                    "name": "Code Visualization",
+                    "recommendations": [{
+                        "name": "cargo-modules",
+                        "link": "https://github.com/regexident/cargo-modules",
+                        "notes": "Renders a crate's module/item structure as a tree or graph"
+                    }]
+                },
+                {
                     "name": "Cross Compilation",
                     "recommendations": [{
                         "name": "cross",


### PR DESCRIPTION
Adds `cargo-module` a cargo plugin for visualizing and analyzing a crate's code structure.

(Disclaimer: I am the author.)