### PR TITLE
Correct links to lib.rs

### DIFF
--- a/templates/macros/crate_table.html
+++ b/templates/macros/crate_table.html
@@ -29,7 +29,7 @@
 
           {% for crate in purpose.recommendations %}
             <p style="margin: 3px 6px;max-width: 600px">
-              <b><a target="_blank" href="{% if crate.link %}{{ crate.link }}{% else %}https://lib.rs/{{ crate.name }}{% endif %}">{{ crate.name }}</a></b>{% if not crate.link %}
+              <b><a target="_blank" href="{% if crate.link %}{{ crate.link }}{% else %}https://lib.rs/crate/{{ crate.name }}{% endif %}">{{ crate.name }}</a></b>{% if not crate.link %}
                 <a target="_blank" style="margin-left: 3px;opacity: 0.7;color: #333;text-decoration: none" href="https://docs.rs/{{ crate.name }}"> [docs]</a>
               {% endif %}
               <br />


### PR DESCRIPTION
Currently the links to lib.rs do not link to the crate itself but instead either link to keywords or nothing at all. This adds the necessary `/crates/` 

Examples:

- Current link to `once_cell` crate [https://lib.rs/once_cell](https://lib.rs/once_cell). This goes to a page not found
  - Correct link to `once_cell` crate [https://lib.rs/crates/once_cell](https://lib.rs/crates/once_cell)
- Current link to `time` crate [https://lib.rs/time](https://lib.rs/time). This redirects to the time keywords page instead of the crate.
  - Correct link to `time` crate [https://lib.rs/crates/time](https://lib.rs/crates/time)