### PR TITLE
Rename crates

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -628,7 +628,7 @@
                         {
                             "name": "Low-level",
                             "recommendations": [{
-                                "name": "tungstenite-rs",
+                                "name": "tungstenite",
                                 "notes": "Low-level crate that others build on"
                             }]
                         },
@@ -947,7 +947,7 @@
                         {
                             "name": "GTK",
                             "recommendations": [{
-                                "name": "gtk4-rs",
+                                "name": "gtk4",
                                 "notes": "Rust bindings to GTK4. These are quite well supported, although you'll often need to use the C documentation."
                             }, {
                                 "name": "relm4",


### PR DESCRIPTION
The link to the following crate is "Page not found".
- tungstenite-rs
- gtk4-rs

I fixed the crate name as it seems `-rs` is unnecessary.