### PR TITLE
Add macroquad to Game Engines

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -997,6 +997,9 @@
                             }, {
                                 "name": "ggez",
                                 "notes": "A simpler option for 2d games only."
+                            }, {
+                                "name": "macroquad",
+                                "notes": "A simple and easy to use 2d game library, great for beginners."
                             }]
                         },
                         {


### PR DESCRIPTION
This adds [`macroquad`](https://github.com/not-fl3/macroquad) ([crate](https://lib.rs/crates/macroquad)) to the list of game engines. Here are some resources:
- [Macroquad website](https://macroquad.rs/) with examples
- [Awesome Quads](https://github.com/ozkriff/awesome-quads): Curated list of links to miniquad/macroquad-related code & resources