### PR TITLE
Rename arc_swap to arc-swap

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -893,7 +893,7 @@
                         {
                             "name": "Atomic pointer swapping",
                             "recommendations": [{
-                                "name": "arc_swap",
+                                "name": "arc-swap",
                                 "notes": "Useful for sharing data that has many readers but few writers"
                             }]
                         },


### PR DESCRIPTION
The crate name of `arc-swap` currently uses a underscore instead of a hyphen. When visiting the link you will get a "Crate not found" error.

This change renames `arc_swap` to `arc-swap` and fixes the not found error.