### PR TITLE
Fix diesel entry + add diesel-async

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -697,12 +697,16 @@
                         },
                         {
                             "name": "ORMs",
-                            "recommendations": [{
-                                "name": "sea-orm",
-                                "notes": "Recommended. Built on top of sqlx. There is also a related sea-query crate that provides a query builder without full ORM functionality."
-                            }, {
+                            "recommendations": [
+                            {
                                 "name": "diesel",
-                                "notes": "Stable release is sync only. Pre-release async branch is currently AGPL. Can provide better performance in some circumstances."
+                                "notes": "Sync only. Provides better performance, stricter compile time guarantees and greater extensibility. See diesel-async for an async connection implementation."
+                            }, {
+                                "name": "sea-orm",
+                                "notes": "Async only. Built on top of sqlx. There is also a related sea-query crate that provides a query builder without full ORM functionality."
+                            }, {
+                                "name": "diesel-async",
+                                "notes": "Async connection implementation for diesel"
                             }]
                         },
                         {
@@ -744,6 +748,9 @@
                         {
                             "name": "Oracle",
                             "recommendations": [{
+                                "name": "diesel-oci",
+                                "notes": "Diesel backend and connection implementation for oracle databases",
+                            }, {
                                 "name": "oracle",
                                 "notes": "Rust bindings to ODPI-C"
                             }]


### PR DESCRIPTION
This PR fixes several serve issues with the diesel entry. I consider the old entry as factually wrong and misleading, especially the unclear language around performance compared to other database entries. For `tokio-postgres` the wording of performance compared to sqlx is much more concrete than the diesel version, even if this sentence is likely based on the same numbers. Also the entry sounds like being sync-only is a large problem, which to repeat me again is not true (or at least not more an issue than being async only!)
Please correct this factual wrong statements as soon as possible. 

In addition it adds `diesel-oci` as potential option for connecting to oracle databases. Finally it removes the `Recommend` attribute for `Sea-ORM` as given the limited extensibility, much worser performance and pre 1.0 state of the crate seems to be misleading. (Please do not understand that as critic at `Sea-ORM`. It's just that both diesel and sea-orm are designed for different use cases and you cannot recommend one or the other without knowing much about the exact use-case.


Fix #56
Fix #57