### PR TITLE
Remove mention of hyper supporting HTTP/3

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -633,7 +633,7 @@
                             "name": "Low-level HTTP Implementation",
                             "recommendations": [{
                                 "name": "hyper",
-                                "notes": "A low-level HTTP implementation (both client and server). Implements HTTP 1, 2, and 3. Works best with the tokio async runtime, but can support other runtimes."
+                                "notes": "A low-level HTTP implementation (both client and server). Implements HTTP/1, and HTTP/2. Works best with the tokio async runtime, but can support other runtimes."
                             }]
                         },
                         {


### PR DESCRIPTION
Not implemented yet. See https://github.com/hyperium/hyper/issues/1818