### PR TITLE
Mention that crossbeam-channel as the same algorithm as std

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -1054,7 +1054,7 @@
                             "recommendations": [
                             {
                                 "name": "crossbeam-channel",
-                                "notes": "The absolute fastest channel implementation available. Implements Go-like 'select' feature."
+                                "notes": "The same channel algorithm as in the standard library but with a more powerful API, offering a Go-like 'select' feature."
                             }, {
                                 "name": "flume",
                                 "notes": "Smaller and simpler than crossbeam-channel and almost as fast"


### PR DESCRIPTION
They now share the same algorithm after <https://github.com/rust-lang/rust/pull/93563>. As far as I’m aware, nowadays the main benefit of crossbeam-channel is its API.