### PR TITLE
remove unneeded opionated messages

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -1152,10 +1152,10 @@
                     "purposes": [
                         {
                             "name": "Game Engines",
-                            "notes": "Bevy is the clear winner for complex games (and especially 3D games). For those wanting something simpler, both ggez and macroquad are good options",
+                            "notes": "Bevy is an ECS based game engine, good for 3D but can also do 2D. For those wanting something simpler, both ggez and macroquad are good options",
                             "recommendations": [{
                                 "name": "bevy",
-                                "notes": "By far the most developed Rust game engine. It's still early, but already impressive and very much useable."
+                                "notes": "It's still early, but already impressive and very much useable."
                             }, {
                                 "name": "ggez",
                                 "notes": "A simpler option for 2d games only."

--- a/data/crates.json
+++ b/data/crates.json
@@ -1152,10 +1152,10 @@
                     "purposes": [
                         {
                             "name": "Game Engines",
-                            "notes": "Bevy is an ECS based game engine, good for 3D but can also do 2D. For those wanting something simpler, both ggez and macroquad are good options",
+                            "notes": "",
                             "recommendations": [{
                                 "name": "bevy",
-                                "notes": "It's still early, but already impressive and very much useable."
+                                "notes": "An ECS based game engine, good for 3D but also capable of 2D."
                             }, {
                                 "name": "ggez",
                                 "notes": "A simpler option for 2d games only."


### PR DESCRIPTION
No other category seemed to have a category note saying which one was a "clear winner" as a result it felt weird to me that the gamedev section did have this. So, this PR changes that.

