### PR TITLE
Add `cargo-semver-checks` to linting category

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -20,6 +20,10 @@
                         "name": "clippy",
                         "link": "https://github.com/rust-lang/rust-clippy#usage",
                         "notes": "The official Rust linter."
+                    }, {
+                        "name": "cargo-semver-checks",
+                        "link": "https://github.com/obi1kenobi/cargo-semver-checks",
+                        "notes": "Lint your crate releases for semantic versioning violations."
                     }]
                 },
                 {


### PR DESCRIPTION
`cargo-semver-checks` is used by many large projects in the Rust ecosystem, such as `tokio` and even `cargo` itself. Add it as a recommendation in the linting category.

If you feel a different category would be a better fit, I'd be happy to move it there.

Thanks for maintaining this list!