### PR TITLE
Add `divan`

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -76,6 +76,9 @@
                         "name": "criterion",
                         "notes": "Statistically accurate benchmarking tool for benchmarking libraries"
                     }, {
+                        "name": "divan",
+                        "notes": "Simple yet powerful benchmarking library with allocation profiling"
+                    }, {
                         "name": "hyperfine",
                         "link": "https://github.com/sharkdp/hyperfine#hyperfine",
                         "notes": "Tool for benchmarking compiled binaries (similar to unix time command but better)"


### PR DESCRIPTION
Adds [`divan`](https://docs.rs/divan) to benchmarking category. Divan has been seeing quick adoption in the Rust ecosystem in the ~3 months since it was first announced.