### PR TITLE
Add heed to the Other Databases list

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -827,6 +827,14 @@
                             }]
                         },
                         {
+                            "name": "LMDB",
+                            "notes": "<a href=\"https://github.com/mozilla/rkv\">The rkv crate</a> depends on <a href=\"https://github.com/mozilla/lmdb-rs\">the lmdb-rkv dependency</a> which is archived and is inactive.",
+                            "recommendations": [{
+                                "name": "heed",
+                                "notes": "A fully typed LMDB wrapper with minimum overhead."
+                            }]
+                        },
+                        {
                             "name": "Rocks DB",
                             "recommendations": [{
                                 "name": "rocksdb"
@@ -1103,9 +1111,9 @@
                                 "name": "ribir",
                                 "link": "https://ribir.org/"
                             },
-                            { "name": "cushy" }, 
-                            { "name": "rui" }, 
-                            { "name": "concoct" }, 
+                            { "name": "cushy" },
+                            { "name": "rui" },
+                            { "name": "concoct" },
                             { "name": "kas" }]
                         }, {
                             "name": "Window creation",


### PR DESCRIPTION
Hello 👋

This PR adds heed to the list of Other Databases. The Mozilla RKV crates depend on an inactive crate, and heed is more maintained and supports more LMDB features.