### PR TITLE
Remove warning about Rocket's unstable async support

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -681,7 +681,7 @@
                             }],
                             "see_also": [{
                                 "name": "rocket",
-                                "notes": "Has an excellent API and a solid implementation. However development has been intermittent, and the async branch still doesn't have a stable release. Use of rocket is not recommended until this has been fixed."
+                                "notes": "Has an excellent API and a solid implementation. However development has been intermittent."
                             }, {
                                 "name": "poem",
                                 "notes": "Automatically generates OpenAPI definitions."


### PR DESCRIPTION
Rocket has since had a [stable release of 0.5](https://rocket.rs/v0.5/news/2023-11-17-version-0.5/) with async support.

I'm happy to discuss & iterate on the phrasing, I just think it's important to update the factual info.

We could consider adding something about Rocket's batteries-included approach, because I think that's the main reason people choose it over axum or actix-web. Excellent API & solid implementation are things that apply to axum & actix-web as well, so from this text the only difference seems to be the questionable maintenance status.