### PR TITLE
Add xflags as cli library

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -893,6 +893,14 @@
                             }]
                         },
                         {
+                            "name": "Some features, quite minimal",
+                            "recommendations": [{
+                                "name": "xflags",
+                                "link": "https://github.com/matklad/xflags",
+                                "notes": "If you want to get things done fast (eg, you want auto help, but not at the cost of waiting for syn to compile), consider xflags."
+                            }]
+                        },
+                        {
                             "name": "Minimal",
                             "recommendations": [{
                                 "name": "lexopt",


### PR DESCRIPTION
This PR adds [`xflags`](https://github.com/matklad/xflags) as `cli` library, as a fast middleground between `clap` and `lexopt`.