### PR TITLE
Remove a duplicate row

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -237,17 +237,6 @@
                                 "name": "tinyvec",
                                 "notes": "Stack allocated arrays in 100% safe Rust code but requires items to implement the Default trait."
                             }]
-                        },
-                        {
-                            "name": "HTTP Requests",
-                            "notes": "See the HTTP section below for server-side libraries",
-                            "recommendations": [{
-                                "name": "reqwest",
-                                "notes": "Full-fat HTTP client. Can be used in both synchronous and asynchronous code. Requires tokio runtime."
-                            }, {
-                                "name": "ureq",
-                                "notes": "Minimal synchronous HTTP client focussed on simplicity and minimising dependencies."
-                            }]
                         }
                     ]
                 },


### PR DESCRIPTION
'HTTP Requests' row in 'General' section duplicates 'HTTP Client' row in 'HTTP' section. Since we have a section dedicated to HTTP, the row in the 'General' section is not needed.