### PR TITLE
Add rustix

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -388,6 +388,9 @@
                         {
                             "name": "*nix (OSs)",
                             "recommendations": [{
+                                "name": "rustix",
+                                "notes": "Efficient and safe POSIX / *nix / Winsock syscall-like APIs. It uses idiomatic Rust types: refs, slices, Results instead of raw pointers, safe wrappers around raw file descriptors, bitflags instead of bare integer flags, and several other conveniences."
+                            }, {
                                 "name": "nix",
                                 "notes": "Bindings to the various *nix system functions. (Unix, Linux, MacOS, etc.)"
                             }]


### PR DESCRIPTION
Fixes: https://github.com/nicoburns/blessed-rs/issues/135

---

Crate description from readme:

> rustix provides efficient memory-safe and [I/O-safe](https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md) wrappers to POSIX-like, Unix-like, Linux, and Winsock syscall-like APIs, with configurable backends. It uses Rust references, slices, and return values instead of raw pointers, and [I/O safety types](https://doc.rust-lang.org/stable/std/os/fd/index.html#structs) instead of raw file descriptors, providing memory safety, [I/O safety](https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md), and [provenance](https://github.com/rust-lang/rust/issues/95228). It uses Results for reporting errors, [bitflags](https://lib.rs/crates/bitflags) instead of bare integer flags, an [Arg](https://docs.rs/rustix/*/rustix/path/trait.Arg.html) trait with optimizations to efficiently accept any Rust string type, and several other efficient conveniences.

Simplified description for this PR:

> Efficient and safe POSIX / *nix / Winsock syscall-like APIs. It uses idiomatic Rust types: refs, slices, Results instead of raw pointers, safe wrappers around raw file descriptors, bitflags instead of bare integer flags, and several other conveniences.

Perhaps add some opinion-sauce to this if needed.