### PR TITLE
Add darling to "macros helpers" section

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -337,6 +337,9 @@
                             }, {
                                 "name": "paste",
                                 "notes": "Concatenating and manipulating identifiers"
+                            }, {
+                                "name": "darling",
+                                "notes": "Derive macro to easily parse derive macro inputs"
                             }]
                         },
                         {


### PR DESCRIPTION
Nice website! As a regular Rust user for the past 5 years I did appreciate when going through the list that it wasn't bloated with tons of crates and I may definitely refer to it. An absolute game changer one is missing in its section though: `darling`, and I did regret not learning about it earlier than ~a year ago. 

It's an absolute must when writing derive macros. It makes writing them 10x easier. It has 8M downloads a month and is top 10 in "Rust patterns" on lib.rs.

https://lib.rs/crates/darling