### PR TITLE
Add sibyl to Oracle Database section

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -825,6 +825,9 @@
                             }, {
                                 "name": "oracle",
                                 "notes": "Rust bindings to ODPI-C"
+                            }, {
+                                "name": "sibyl",
+                                "notes": "An OCI-based interface supporting both blocking (threads) and nonblocking (async) AP"
                             }]
                         }
                     ]


### PR DESCRIPTION
This PR adds [sibyl](https://lib.rs/crates/sibyl) as a database interface for Oracle DBs. It supports nonblocking (async) API out of the box.