### PR TITLE
Tweak serialization section layout, update README with info on running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # [Blessed.rs](https://blessed.rs)
 
 A community guide to the Rust ecosystem
+
+## Testing locally
+
+```
+cargo build --release
+docker build . -t blessed-rs
+docker run -p 3333:3333 blessed-rs
+< check localhost:3333 in browser>
+```

--- a/data/crates.json
+++ b/data/crates.json
@@ -179,14 +179,6 @@
                             }]
                         },
                         {
-                            "name": "Serialization (JSON, YAML, etc)",
-                            "notes": "See <a href=\"https://docs.rs/serde/latest/serde/#data-formats\">here</a> for supported formats.",
-                            "recommendations": [{
-                                "name": "serde",
-                                "notes": "De facto standard serialization library. Use in conjunction with sub-crates like serde_json for the specific format that you are using."
-                            }]
-                        },
-                        {
                             "name": "Regular Expressions",
                             "recommendations": [{
                                 "name": "regex",
@@ -362,10 +354,11 @@
                 {
                     "slug": "serialization",
                     "name": "Serialization",
-                    "description": "Encode/decode between in-memory representations and general-purpose wire formats. Wire formats can be text (human readable) or binary (machine-readable only). Protocols can be self-describing (the receiving end does not need prior knowledge of the protocol) or non-self-describing (receiving end needs external context to deserialize). Some non-self-describing formats have an external schema file, which better supports cross-language bindings and schema evolution. Non-self-describing formats without a schema file tend to be Rust-only, with a shared Rust type definition.",
+                    "description": "Encode/decode between in-memory representations and general-purpose wire formats",
                     "purposes": [
                         {
                             "name": "General-purpose / format agnostic",
+                            "notes": "This includes self-describing formats (receiving end needs no prior knowledge of protocol) that are both text (human readable) and binary (not human-readable).",
                             "recommendations": [{
                                 "name": "serde",
                                 "notes": "De facto standard serialization library. Use in conjunction with sub-crates like `serde_json` for the specific format that you are using (JSON, YAML, etc). Supports a variety of both text and binary protocols, including self-describing ones."
@@ -373,19 +366,21 @@
                         },
                         {
                             "name": "Non-self-describing, external schema file",
+                            "notes": "Non-self-describing formats with an external schema file tend to better support cross-language bindings as well as schema evolution.",
                             "recommendations": [{
                                 "name": "prost",
                                 "notes": "Protocol buffer library with strong ergonomics and wide industry adoption. Commonly used with gRPC / `tonic`. Use in conjunction with `protox` to avoid dependency on `protoc`."
                             }, {
                                 "name": "capnp",
-                                "notes": "Cap'n Proto library. Offers zero-copy usage mode that is optimal for large messages, along with other improvements over Protocol Buffers .Tradeoffs are less widely usage and less developer-friendly."
+                                "notes": "Cap'n Proto library. Offers zero-copy usage mode that is optimal for large messages, along with other improvements over Protocol Buffers. Tradeoffs are less wide usage and less developer-friendly."
                             }, {
                                 "name": "flatbuffers",
-                                "notes": "Flatbuffers library. Also offers zero-copy usage and is more widely used than cap'n proto, with further cost of ergonomics."
+                                "notes": "Flatbuffers library. Also offers zero-copy usage and is more widely used than cap'n proto, with further cost to ergonomics."
                             }]
                         },
                         {
                             "name": "Non-self-describing, no external schema file",
+                            "notes": "Non-self-describing formats without a schema file tend to be Rust-only, with a shared Rust type definition.",
                             "recommendations": [{
                                 "name": "postcard",
                                 "notes": "`!#[no_std]`-focused Serde serializer/deserializer, aimed at constrained environments."


### PR DESCRIPTION
Follow up to: #144

The new serialization section layout was pretty rough. I figured out how to test locally and cleaned it up by adding notes per-row instead.

Also threw instructions on testing into the README.
![Screenshot 2024-12-30 at 11 59 08 AM](https://github.com/user-attachments/assets/141b1d0c-31ff-4ede-9251-7d379ea2ae74)



