### PR TITLE
Explicitly specify a link for the termcolor crate

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -1016,6 +1016,7 @@
                             "name": "Coloured Output",
                             "recommendations": [{
                                 "name": "termcolor",
+                                "link": "https://crates.io/crates/termcolor",
                                 "notes": "Cross-platform terminal colour output"
                             }]
                         },


### PR DESCRIPTION
Currently the link to lib.rs is used (https://lib.rs/crates/termcolor), but the author prefers not to be listed on lib.rs, so it only shows the following message instead of an actual crate:
> Owner of this crate does not want it to be on lib.rs
>
>    lib.rs calls cryptocurrencies a magic beans scam, etc. BurntSushi doesn't want to be a party to what he sees as sneering or similar editorializing on a web site that he perceives to be a crate index. (Even if he agrees with the substance of the editorial.)[*](https://gitlab.com/crates.rs/crates.rs/-/issues/121#note_1178288733)