### PR TITLE
Add info about magnus

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -514,6 +514,7 @@
                 {
                     "name": "Ruby",
                     "recommendations": [
+                        { "name": "magnus", "notes": "Ruby bindings for Rust. Write Ruby extension gems in Rust, or call Ruby from Rust. Supported by Ruby's rubygems and bundler" },
                         { "name": "rutie", "notes": "Supports both embedding Rust into Ruby applications and embedding Ruby into Rust applications" }
                     ]
                 },


### PR DESCRIPTION
[Magnus](https://github.com/matsadler/magnus) is officially supported by Ruby now, so I believe it should be listed here as a Ruby interop