### PR TITLE
add `cc` to the FFI/Interop section

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -500,7 +500,8 @@
                     "name": "C",
                     "recommendations": [
                         { "name": "bindgen", "notes": "Generate Rust bindings to C libraries" },
-                        { "name": "cbindgen", "notes": "Generate C bindings to Rust libraries" }
+                        { "name": "cbindgen", "notes": "Generate C bindings to Rust libraries" },
+                        { "name": "cc", "notes": "Compile and link C code as part of your Cargo build" }
                     ]
                 },
                 {


### PR DESCRIPTION
As far as I know, `cc` is the de facto standard for building C code as part of a Rust crate. I use it in production in several places myself. I think the `cc` + `bindgen` combo is a great thing to teach.