### PR TITLE
Remove winapi

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -265,9 +265,6 @@
                             "recommendations": [{
                                 "name": "windows",
                                 "notes": "The official Microsoft-provided crate for interacting with windows APIs"
-                            }, {
-                                "name": "winapi",
-                                "notes": "Older binding to the windows APIs. Unofficial, but more complete than windows-rs"
                             }]
                         },
                         {


### PR DESCRIPTION
https://github.com/retep998/winapi-rs doesn't seem to be maintained anymore, last commit in 2021.

Also see https://github.com/retep998/winapi-rs/issues/1055