### PR TITLE
Add salvo to HTTP Server see_also

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -764,6 +764,9 @@
                                 "name": "warp",
                                 "notes": "Very similar to axum but with a quirkier API. This is a solid framework, but you should probably prefer Axum unless you particularly like the API"
                             }, {
+                                "name": "salvo",
+                                "notes": "Hyper/tokio-based with simplified handler signatures (no complex generic bounds), built-in OpenAPI and TLS/ACME."
+                            }, {
                                 "name": "rocket",
                                 "notes": "Has an excellent API and a solid implementation. However development has been intermittent."
                             }, {

--- a/data/crates.json
+++ b/data/crates.json
@@ -761,14 +761,14 @@
                                 "notes": "A performance focused framework. All Rust frameworks are fast, but choose actix-web if you need the absolutely maximum performance."
                             }],
                             "see_also": [{
+                                "name": "warp",
+                                "notes": "Very similar to axum but with a quirkier API. This is a solid framework, but you should probably prefer Axum unless you particularly like the API"
+                            }, {
                                 "name": "rocket",
                                 "notes": "Has an excellent API and a solid implementation. However development has been intermittent."
                             }, {
                                 "name": "poem",
                                 "notes": "Automatically generates OpenAPI definitions."
-                            }, {
-                                "name": "warp",
-                                "notes": "Very similar to axum but with a quirkier API. This is a solid framework, but you should probably prefer Axum unless you particularly like the API"
                             }, {
                                 "name": "tide",
                                 "notes": "Similar to Axum, but based on async-std rather than tokio"


### PR DESCRIPTION
Adds [salvo](https://github.com/salvo-rs/salvo) to the HTTP Server section under `see_also`.

### Why

salvo is an actively maintained hyper/tokio-based web framework (~4.3k stars, last push within the week). It already shows up alongside axum/actix/rocket/poem/warp on the other major Rust web discovery lists — [awesome-rust](https://github.com/rust-unofficial/awesome-rust) and [Are We Web Yet?](https://github.com/rust-lang/arewewebyet/blob/gh-pages/content/topics/frameworks.md) — and has an entry in TechEmpower FrameworkBenchmarks. blessed.rs appears to be the only one of the established discovery resources that doesn't list it.

### Where it fits

It belongs in `see_also` rather than `recommendations`: axum/actix-web are the right defaults; salvo is the right pointer for users who want simpler handler signatures (no complex generic bounds), and who want OpenAPI generation and TLS/ACME built into the framework rather than wired up separately.

I kept the note one line, matching the style of the other entries.