### PR TITLE
Replase paste with pastey

### DIFF
--- a/data/crates.json
+++ b/data/crates.json
@@ -192,7 +192,10 @@
                                 "notes": "Quasi quoting rust (useful for interpolating generated code with literal code)"
                             }, {
                                 "name": "paste",
-                                "notes": "Concatenating and manipulating identifiers"
+                                "notes": "Concatenating and manipulating identifiers, currently unmaintained"
+                            }, {
+                                "name": "pastey",
+                                "notes": "Successor and drop in replacement of paste crate"
                             }, {
                                 "name": "darling",
                                 "notes": "Derive macro to easily parse derive macro inputs"

--- a/data/crates.json
+++ b/data/crates.json
@@ -191,11 +191,8 @@
                                 "name": "quote",
                                 "notes": "Quasi quoting rust (useful for interpolating generated code with literal code)"
                             }, {
-                                "name": "paste",
-                                "notes": "Concatenating and manipulating identifiers, currently unmaintained"
-                            }, {
                                 "name": "pastey",
-                                "notes": "A successor and drop-in replacement for the paste crate"
+                                "notes": "Concatenating and manipulating identifiers"
                             }, {
                                 "name": "darling",
                                 "notes": "Derive macro to easily parse derive macro inputs"

--- a/data/crates.json
+++ b/data/crates.json
@@ -195,7 +195,7 @@
                                 "notes": "Concatenating and manipulating identifiers, currently unmaintained"
                             }, {
                                 "name": "pastey",
-                                "notes": "Successor and drop in replacement of paste crate"
+                                "notes": "A successor and drop-in replacement for the paste crate"
                             }, {
                                 "name": "darling",
                                 "notes": "Derive macro to easily parse derive macro inputs"


### PR DESCRIPTION
[`pastey`](https://lib.rs/crates/pastey) is a successor to the [`paste`](https://lib.rs/crates/paste) crate.
As of 2026-06-28, the `paste` crate is no longer maintained and has been [archived](https://github.com/dtolnay/paste) (2024-10-6)

---

`pastey` have 8,7 mil monthly downloads, #8 in [no standard library](https://lib.rs/no-std) category.
used in 3,153 crates (204 directly) and **maintained**

_Info from lib.rs_